### PR TITLE
Invalid order responses

### DIFF
--- a/Solid.Arduino.Test/IFirmataProtocolTester.cs
+++ b/Solid.Arduino.Test/IFirmataProtocolTester.cs
@@ -964,19 +964,26 @@ namespace Solid.Arduino.Test
 
         [TestMethod]
         public void MixedOrderResponses()
-        {
-            var connection = new MockSerialConnection();
-            var session = CreateFirmataSession(connection, 3);
+         {
+             var connection = new MockSerialConnection();
+             var session = CreateFirmataSession(connection, 3);
 
             // We get first ProtocolVersion response and then FirmwareResponse
             connection.EnqueueRequestAndResponse(new byte[] { 0xF0, 0x79, 0xF7 },
                 new byte[]
                 {
-                    0xF9, 0x02, 0x04, 0xF0, 0x79, 0x01, 0x03, 0x65, 0x00, 0x56, 0x00, 0x65, 0x00, 0x6E, 0x00, 0x75, 0x00,
-                    0x73, 0x00, 0x4D, 0x00, 0x6F, 0x00, 0x64, 0x00, 0x75, 0x00, 0x6C, 0x00, 0x65, 0x00, 0xF7
+                    0xF9, 0x02, 0x04, 0xF0, 
+                    0x79, 
+                    0x01, 0x03,                    
+                    0x74, 0x00, 0x65, 0x00, 0x73, 0x00, 0x74, 0x00,
+                    0xF7
                 });
-            session.GetFirmware();
-        }
+             var f = session.GetFirmware();
+             Assert.AreEqual(1, f.MajorVersion);
+             Assert.AreEqual(3, f.MinorVersion);
+             Assert.AreEqual("test", f.Name);
+         }
+
 
         private IFirmataProtocol CreateFirmataSession(ISerialConnection connection, int timeout = -1)
         {

--- a/Solid.Arduino/Firmata/FirmataMessage.cs
+++ b/Solid.Arduino/Firmata/FirmataMessage.cs
@@ -9,14 +9,14 @@ namespace Solid.Arduino.Firmata
     {
         private readonly MessageType _type;
         private readonly ValueType _value;
+        private readonly DateTime _time;
 
         /// <summary>
         /// Initializes a new <see cref="FirmataMessage"/> instance.
         /// </summary>
         /// <param name="type">The type of message to be created.</param>
-        internal FirmataMessage(MessageType type)
+        internal FirmataMessage(MessageType type): this (null, type, DateTime.UtcNow)
         {
-            _type = type;
         }
 
         /// <summary>
@@ -24,10 +24,21 @@ namespace Solid.Arduino.Firmata
         /// </summary>
         /// <param name="value"></param>
         /// <param name="type"></param>
-        internal FirmataMessage(ValueType value, MessageType type)
+        internal FirmataMessage(ValueType value, MessageType type): this (value, type, DateTime.UtcNow)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="FirmataMessage"/> instance.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="type"></param>
+        /// <param name="time"></param>
+        internal FirmataMessage(ValueType value, MessageType type, DateTime time)
         {
             _value = value;
             _type = type;
+            _time = time;
         }
 
         /// <summary>
@@ -39,6 +50,11 @@ namespace Solid.Arduino.Firmata
         /// Gets the type enumeration of the message.
         /// </summary>
         public MessageType Type { get { return _type; } }
+
+        /// <summary>
+        /// Gets the time of the delivered message.
+        /// </summary>
+        public DateTime Time { get { return _time; } }
     }
 
     /// <summary>


### PR DESCRIPTION
Some time Firmata's end device sends messages without our previous request, even this situation must be handled by our Firmata .net implementation. MixedOrderResponses test demonstrates such case. In my second commit I'm sending solution.
