### PR TITLE
Fixed ArduinoSession Dispose Bug

### DIFF
--- a/Solid.Arduino/ArduinoSession.cs
+++ b/Solid.Arduino/ArduinoSession.cs
@@ -758,7 +758,7 @@ namespace Solid.Arduino
 
         public void Dispose()
         {
-            if (_gotOpenConnection)
+            if (!_gotOpenConnection)
             {
                 _connection.Close();
             }


### PR DESCRIPTION
Fixed bug where a session would close its serialconnection if it was opened before the session was created instead of only closing it when it opened it itself.

In the constructor of the session:

```
 _connection = connection;
 _gotOpenConnection = connection.IsOpen;

if (!connection.IsOpen)
    connection.Open();
```

In the dispose:

```
if (_gotOpenConnection)
{
     _connection.Close();
}
```

So the session would close its underlying connection ONLY IF it was already opened? This would break:

```
using(var session = new ArduinoSession(connection))
{
}
```

Because if connection was not yet opened, then `_gotOpenConnection = false` and at the end of the using, when `Dispose` is called on the session, it would NOT close the underlying connection, which is undesirable because it would leave the connection open where you would presume the using statement would close it.