### PR TITLE
Implemented a getter on the serial connection in ArduinoSession

### DIFF
--- a/Solid.Arduino/ArduinoSession.cs
+++ b/Solid.Arduino/ArduinoSession.cs
@@ -213,6 +213,14 @@ namespace Solid.Arduino
             }
         }
 
+        /// <summary>
+        /// Get the ISerialConnection from the ArduinoSession Instance.
+        /// </summary>
+        public ISerialConnection Connection
+        {
+            get { return _connection; }
+        }
+
         #region IStringProtocol
 
         /// <inheritdoc cref="IStringProtocol.StringReceived"/>


### PR DESCRIPTION
I am implementing a multiple arduino engine that can read/write and receive data from multiple arduinos. Lacking of a unique identifier I tought about putting a getter on the serial connection to be able to identify the arduino by their port name.